### PR TITLE
ci: add tag-triggered release support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,8 @@ name: CI/CD Pipeline
 on:
   push:
     branches: [ main, github_main ]
+    tags:
+      - 'v*'  # Trigger on version tags like v0.3.3
   pull_request:
     branches: [ main, github_main ]
   workflow_dispatch:
@@ -180,12 +182,21 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     needs: [build]
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
+    if: (github.event_name == 'workflow_dispatch' && github.event.inputs.version != '') || startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Get version
+      id: get_version
+      run: |
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+        else
+          echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        fi
 
     - name: Download all artifacts
       uses: actions/download-artifact@v4
@@ -200,7 +211,7 @@ jobs:
         
         # Create a zip file with all binaries
         cd release-assets
-        zip -r "../one-mcp-binaries-${{ github.event.inputs.version }}.zip" .
+        zip -r "../one-mcp-binaries-${{ steps.get_version.outputs.version }}.zip" .
         cd ..
 
     - name: Create Release
@@ -209,8 +220,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.event.inputs.version }}
-        release_name: Release ${{ github.event.inputs.version }}
+        tag_name: ${{ steps.get_version.outputs.version }}
+        release_name: Release ${{ steps.get_version.outputs.version }}
         draft: false
         prerelease: false
 
@@ -220,8 +231,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./one-mcp-binaries-${{ github.event.inputs.version }}.zip
-        asset_name: one-mcp-binaries-${{ github.event.inputs.version }}.zip
+        asset_path: ./one-mcp-binaries-${{ steps.get_version.outputs.version }}.zip
+        asset_name: one-mcp-binaries-${{ steps.get_version.outputs.version }}.zip
         asset_content_type: application/zip
 
     - name: Upload individual binaries

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@
 *.out
 .gocache/
 .cache/
-.github/
 # Dependency directories (remove the comment below to include it)
 # vendor/
 


### PR DESCRIPTION
- Add trigger on push tags 'v*'
- Release job now runs on both workflow_dispatch and tag push
- Dynamically get version from tag or input
- Remove .github/ from .gitignore