### PR TITLE
Build with patched Go toolchain

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.26.2'
         cache: true
 
     - name: Set up Node.js
@@ -71,7 +71,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.26.2'
         cache: true
 
     - name: Install dependencies
@@ -133,7 +133,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.26.2'
         cache: true
 
     - name: Set up Node.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY ./VERSION .
 RUN npm install
 RUN REACT_APP_VERSION=$(cat VERSION) npm run build
 
-FROM --platform=$BUILDPLATFORM golang AS builder2
+FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder2
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module one-mcp
 
-// +heroku goVersion go1.24
-go 1.24
+// +heroku goVersion go1.26.2
+go 1.26.2
 
 require (
 	github.com/burugo/thing v0.1.26


### PR DESCRIPTION
## Summary
- raise the module Go directive and Heroku metadata to Go 1.26.2
- pin all GitHub Actions Go setup steps to Go 1.26.2
- pin the Docker Go builder stage to `golang:1.26.2`

## Why
`govulncheck ./...` reported reachable public Go standard-library vulnerabilities in crypto/x509, crypto/tls, html/template, os, and net/url when scanning the current tree. Those findings are fixed by building with Go 1.26.1/1.26.2, so this aligns all build entry points on the patched release.

## Verification
- created the same dummy `frontend/dist/index.html` used by CI before Go tests
- `go test ./...`
- `$(go env GOPATH)/bin/govulncheck ./...` now reports 0 reachable vulnerabilities